### PR TITLE
Fixes TypeError: Cannot read property 'handshaken'

### DIFF
--- a/ep_sotauth.js
+++ b/ep_sotauth.js
@@ -54,7 +54,7 @@ exports.handleMessage = function(hook_name, context, cb) {
       console.debug('ep_sotauth.handleMessage: intercepted CLIENT_READY message has no token!');
     } else {
       var client_id = context.client.id;
-      var express_sid = context.client.manager.handshaken[client_id].sessionID;
+      var express_sid = context.client.client.request.sessionID;
       console.debug('ep_sotauth.handleMessage: intercepted CLIENT_READY message for client_id = %s express_sid = %s, setting username for token %s to %s', client_id, express_sid, context.message.token, sotauthUsername);
       sotauthSetUsername(context.message.token, sotauthUsername[express_sid]);
     }


### PR DESCRIPTION
In a somewhat modern nodejs installation (0.10.37) and updated etherpad-lite (1.5.6) the context instance passed as argument in handleMessage has the sessionID in context.client.client.request.sessionID.
